### PR TITLE
Windows 95-style desktop web UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>WINDOWS</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>WINDOWS 95 WEB</title>
     <link rel="stylesheet" href="./static/css/style.css">
-    <!-- <link rel="stylesheet" href="TemplateData/style.css">
-    <script src="TemplateData/UnityProgress.js"></script>
-    <script src="Build/UnityLoader.js"></script>
-    <script>
-      var unityInstance = UnityLoader.instantiate("unityContainer", "Build/DATA_GALLERY.json", {onProgress: UnityProgress});
-    </script> --> -->
   </head>
-  
+
   <body>
-    <nav class="nav">
-      <div class="dropup">
-        <button class="dropbtn">Start</button>
-          <div class="dropup-content">
-            <a href="/" class="nav__link" data-link> Home</a>
-            <a href="/artgallery" class="nav__link" data-link> Art Gallery</a>
-            <a href="/webdev" class="nav__link" data-link> Web Development</a>
-            <a href="/other" class="nav__link" data-link> Other</a>
-          </div>
-      </div>
-    </nav> 
     <div id="app"></div>
+
+    <nav class="nav" aria-label="Taskbar">
+      <div class="dropup">
+        <button class="dropbtn" type="button">Start</button>
+        <div class="dropup-content">
+          <a href="/" class="nav__link" data-link>🏠 Home</a>
+          <a href="/artgallery" class="nav__link" data-link>🖼️ Art Gallery</a>
+          <a href="/webdev" class="nav__link" data-link>💾 Web Development</a>
+          <a href="/other" class="nav__link" data-link>📁 Other</a>
+        </div>
+      </div>
+      <div class="taskbar-label">Desktop</div>
+    </nav>
+
     <script type="module" src="./static/js/index.js"></script>
   </body>
 </html>

--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -1,62 +1,217 @@
-/* .main-container{
-  width: 100%;
-} */
-
-/* 
-
-.webgl-content * {border: 0; margin: 0; padding: 0; background-color: black; color: white;}
-.webgl-content {position: absolute; top: 50%; left: 50%; -webkit-transform: translate(-50%, -50%); transform: translate(-50%, -50%);}
-
-.webgl-content .logo, .progress {position: absolute; left: 50%; top: 50%; -webkit-transform: translate(-50%, -50%); transform: translate(-50%, -50%);}
-.webgl-content .logo {background: url('progressLogo.Light.png') no-repeat center / contain; width: 154px; height: 130px;}
-.webgl-content .progress {height: 18px; width: 141px; margin-top: 90px;}
-.webgl-content .progress .empty {background: url('progressEmpty.Light.png') no-repeat right / cover; float: right; width: 100%; height: 100%; display: inline-block;}
-.webgl-content .progress .full {background: url('progressFull.Light.png') no-repeat left / cover; float: left; width: 0%; height: 100%; display: inline-block;}
-
-.webgl-content .logo.Dark {background-image: url('progressLogo.Dark.png');}
-.webgl-content .progress.Dark .empty {background-image: url('progressEmpty.Dark.png');}
-.webgl-content .progress.Dark .full {background-image: url('progressFull.Dark.png');}
-
-.webgl-content .footer {margin-top: 5px; height: 38px; line-height: 38px; font-family: Helvetica, Verdana, Arial, sans-serif; font-size: 18px;}
-.webgl-content .footer .webgl-logo, .title, .fullscreen {height: 100%; display: inline-block; background: transparent center no-repeat;}
-.webgl-content .footer .webgl-logo {background-image: url('webgl-logo.png'); width: 204px; float: left;}
-.webgl-content .footer .title {margin-right: 10px; float: right;} 
-.webgl-content .footer .fullscreen {background-image: url('fullscreen.png'); width: 38px; float: right;} */
-
-body{
-  background-color:#118d8d;
+* {
+  box-sizing: border-box;
 }
-.nav{
-  background-color: silver;
-  /* overflow: hidden; */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #008080;
+  color: #000;
+  font-family: "MS Sans Serif", Tahoma, Geneva, sans-serif;
+  font-size: 14px;
+}
+
+#app {
+  min-height: calc(100vh - 44px);
+  padding: 14px;
+}
+
+.desktop {
+  display: grid;
+  grid-template-columns: 120px minmax(280px, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.desktop-icons {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.desktop-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 88px;
+  color: #fff;
+  text-decoration: none;
+  text-align: center;
+  padding: 4px;
+}
+
+.desktop-icon:hover,
+.desktop-icon:focus-visible {
+  outline: 1px dotted #fff;
+  background: rgba(0, 0, 128, 0.45);
+}
+
+.desktop-icon__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  font-size: 28px;
+  background: #c0c0c0;
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #555;
+  border-bottom: 2px solid #555;
+  color: #111;
+}
+
+.desktop-icon__label {
+  line-height: 1.1;
+  text-shadow: 1px 1px #000;
+}
+
+.window {
+  max-width: 620px;
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #404040;
+  border-bottom: 2px solid #404040;
+  background: #c0c0c0;
+  box-shadow: 2px 2px 0 #000;
+}
+
+.window__titlebar {
+  background: linear-gradient(90deg, #000080, #1084d0);
+  color: #fff;
+  padding: 4px 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: bold;
+}
+
+.window__controls {
+  display: flex;
+  gap: 4px;
+}
+
+.window__control {
+  width: 18px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  background: #c0c0c0;
+  color: #000;
+  border-top: 1px solid #fff;
+  border-left: 1px solid #fff;
+  border-right: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+
+.window__body {
+  background: #fff;
+  margin: 10px;
+  padding: 12px;
+  border-top: 2px solid #808080;
+  border-left: 2px solid #808080;
+  border-right: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+}
+
+.window__body p {
+  margin: 0 0 8px;
+}
+
+.window__body ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.nav {
+  background: #c0c0c0;
   position: fixed;
   bottom: 0;
+  left: 0;
   width: 100%;
-  border: 2 outset; margin-left: 0%;
+  border-top: 2px solid #fff;
+  padding: 2px 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 100;
 }
 
-/* Style the links inside the navigation bar */
-.nav a {
-  float: left;
+.dropup {
+  position: relative;
+}
+
+.dropbtn {
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #444;
+  border-bottom: 2px solid #444;
+  background: #c0c0c0;
+  color: #000;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 4px 14px;
+  cursor: pointer;
+}
+
+.dropbtn:active {
+  border-top: 2px solid #444;
+  border-left: 2px solid #444;
+  border-right: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+}
+
+.dropup-content {
+  display: none;
+  position: absolute;
+  bottom: 34px;
+  left: 0;
+  min-width: 220px;
+  background: #c0c0c0;
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #444;
+  border-bottom: 2px solid #444;
+  padding: 6px;
+}
+
+.dropup-content a {
   display: block;
-  color: black;
-  text-align: center;
-  border: 2px outset;
+  color: #000;
   text-decoration: none;
-  font-size: 17px;
- 
-  padding-left: 10px ;
-  padding-right: 10px;
+  padding: 6px 8px;
 }
 
-/* Change the color of links on hover */
-.nav a:hover {
-  background-color: rgb(83, 83, 83);
-  color: black;
+.dropup-content a:hover,
+.dropup-content a:focus-visible {
+  background: #000080;
+  color: #fff;
 }
 
-/* Add a color to the active/current link */
-.nav a.active {
-  background-color: silver;
-  color: black;
+.dropup:hover .dropup-content,
+.dropup:focus-within .dropup-content {
+  display: block;
+}
+
+.taskbar-label {
+  border-top: 1px solid #808080;
+  border-left: 1px solid #808080;
+  border-right: 1px solid #fff;
+  border-bottom: 1px solid #fff;
+  padding: 4px 10px;
+  background: #bcbcbc;
+}
+
+@media (max-width: 760px) {
+  .desktop {
+    grid-template-columns: 1fr;
+  }
+
+  .desktop-icons {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 }

--- a/public/static/js/views/Artgallery.js
+++ b/public/static/js/views/Artgallery.js
@@ -3,18 +3,25 @@ import AbstractView from "./AbstractView.js";
 export default class extends AbstractView {
     constructor(params) {
         super(params);
-        this.setTitle("Home");
+        this.setTitle("Art Gallery");
     }
 
     async getHtml() {
         return `
-            <h1>Data Gallery</h1>
-            <p>
-               small showcase of some art work within a 3d gallery
-            </p>
-            <p>
-                // <a href="/other" data-link>View all</a>.
-            </p>
+            <section class="window">
+                <header class="window__titlebar">
+                    <span>Art Gallery</span>
+                    <div class="window__controls" aria-hidden="true">
+                        <span class="window__control">_</span>
+                        <span class="window__control">▢</span>
+                        <span class="window__control">✕</span>
+                    </div>
+                </header>
+                <div class="window__body">
+                    <p>Small showcase of art work presented in a gallery style experience.</p>
+                    <p>Use the Start menu to jump back to the desktop anytime.</p>
+                </div>
+            </section>
         `;
     }
 }

--- a/public/static/js/views/Home.js
+++ b/public/static/js/views/Home.js
@@ -3,12 +3,47 @@ import AbstractView from "./AbstractView.js";
 export default class extends AbstractView {
     constructor(params) {
         super(params);
-        this.setTitle("Home");
+        this.setTitle("Windows 95 Desktop");
     }
 
     async getHtml() {
         return `
- 
+            <main class="desktop" aria-label="Windows 95 style desktop">
+                <section class="desktop-icons" aria-label="Desktop icons">
+                    <a class="desktop-icon nav__link" href="/artgallery" data-link>
+                        <span class="desktop-icon__glyph">🖼️</span>
+                        <span class="desktop-icon__label">My Gallery</span>
+                    </a>
+                    <a class="desktop-icon nav__link" href="/webdev" data-link>
+                        <span class="desktop-icon__glyph">💾</span>
+                        <span class="desktop-icon__label">Projects</span>
+                    </a>
+                    <a class="desktop-icon nav__link" href="/other" data-link>
+                        <span class="desktop-icon__glyph">📁</span>
+                        <span class="desktop-icon__label">My Documents</span>
+                    </a>
+                </section>
+
+                <section class="window" aria-label="Welcome window">
+                    <header class="window__titlebar">
+                        <span>Welcome.txt - Notepad</span>
+                        <div class="window__controls" aria-hidden="true">
+                            <span class="window__control">_</span>
+                            <span class="window__control">▢</span>
+                            <span class="window__control">✕</span>
+                        </div>
+                    </header>
+                    <div class="window__body">
+                        <p><strong>Welcome to your Windows 95 style desktop.</strong></p>
+                        <p>Use the desktop icons or the Start menu to open sections.</p>
+                        <ul>
+                            <li><strong>My Gallery</strong>: Art showcase.</li>
+                            <li><strong>Projects</strong>: Web development work.</li>
+                            <li><strong>My Documents</strong>: Miscellaneous projects.</li>
+                        </ul>
+                    </div>
+                </section>
+            </main>
         `;
     }
 }

--- a/public/static/js/views/Other.js
+++ b/public/static/js/views/Other.js
@@ -3,13 +3,25 @@ import AbstractView from "./AbstractView.js";
 export default class extends AbstractView {
     constructor(params) {
         super(params);
-        this.setTitle("other");
+        this.setTitle("Other Projects");
     }
 
     async getHtml() {
         return `
-            <h1>Other Projects</h1>
-            
+            <section class="window">
+                <header class="window__titlebar">
+                    <span>Other Projects</span>
+                    <div class="window__controls" aria-hidden="true">
+                        <span class="window__control">_</span>
+                        <span class="window__control">▢</span>
+                        <span class="window__control">✕</span>
+                    </div>
+                </header>
+                <div class="window__body">
+                    <p>Store experiments, utilities, or random cool ideas in this folder.</p>
+                    <p>Think of this section as your digital junk drawer.</p>
+                </div>
+            </section>
         `;
     }
 }

--- a/public/static/js/views/Webdev.js
+++ b/public/static/js/views/Webdev.js
@@ -3,12 +3,25 @@ import AbstractView from "./AbstractView.js";
 export default class extends AbstractView {
     constructor(params) {
         super(params);
-        this.setTitle("Home");
+        this.setTitle("Web Development");
     }
 
     async getHtml() {
         return `
-            <h1>Web Development</h1>
+            <section class="window">
+                <header class="window__titlebar">
+                    <span>Web Development</span>
+                    <div class="window__controls" aria-hidden="true">
+                        <span class="window__control">_</span>
+                        <span class="window__control">▢</span>
+                        <span class="window__control">✕</span>
+                    </div>
+                </header>
+                <div class="window__body">
+                    <p>This area can host your projects, demos, and code samples.</p>
+                    <p>Add links or cards here to feature your best work.</p>
+                </div>
+            </section>
         `;
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a nostalgic Windows 95 desktop experience as the app shell with a Start menu, taskbar, desktop icons, and window chrome.
- Surface routed content inside consistent Win95-style windows so navigation feels cohesive across pages.
- Replace scattered/legacy layout styles with a focused Win95-themed stylesheet to simplify visual design.
- Ensure the UI is usable on smaller viewports with responsive adjustments.

### Description
- Rewrote the app shell in `public/index.html` to include a `#app` mount point, a taskbar, a Start button, and Start menu links.
- Replaced and expanded `public/static/css/style.css` with Win95-inspired styles (desktop teal background, beveled controls, title bars, window chrome, taskbar, Start menu, and responsive rules).
- Implemented a desktop Home view in `public/static/js/views/Home.js` that renders clickable desktop icons and a Notepad-like welcome window.
- Updated route views (`public/static/js/views/Artgallery.js`, `Webdev.js`, `Other.js`) to render inside the new `.window` chrome and set appropriate page titles.

### Testing
- Started the server with `npm start`, and the process started successfully.
- Confirmed the server responded over HTTP using `curl -I http://127.0.0.1:3000`, which returned `HTTP/1.1 200 OK`.
- Committed the changes and verified repository state with `git status --short` and a local commit present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbf05119c8320bf3d979fabde89bf)